### PR TITLE
add some helpfull info to a print command

### DIFF
--- a/indicator/ernesst-indicator-upower.py
+++ b/indicator/ernesst-indicator-upower.py
@@ -139,7 +139,7 @@ class UpowerIndicator(object):
                 self.device_name = config_json['device'].strip()
                 self.read_device_config()
             else:
-                print(path.exists("/system/build.prop"))
+                print("/system/build.prop exists? " + str(path.exists("/system/build.prop")))
                 if path.exists("/system/build.prop"):
                     build_prop_file = open("/system/build.prop")
                     for line in build_prop_file:


### PR DESCRIPTION
Just a small thing. Only printing out TRUE or FALSE here seems not helpful. I just stumbled upon this when searching the source code for build.prop.