### PR TITLE
add note about supported devices and small rephrasing

### DIFF
--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -122,7 +122,7 @@ ApplicationWindow {
             }
             Label {
                id:text2
-                text: "Be aware the displayed data are gathered and processed by Upower tool. There availability is device dependent."
+                text: "Be aware, the displayed data is gathered and processed by Upower tool. Data availability is device dependent."
                 anchors.margins: 5
                 anchors.top: text1.bottom
                 anchors.left: parent.left
@@ -133,9 +133,22 @@ ApplicationWindow {
                 font.pixelSize: 12
             }
             Label {
+               id:text3
+                text: "This app only works on supported devices! Please see the Readme for a list."
+                anchors.margins: 5
+                anchors.top: text2.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+                horizontalAlignment: Label.AlignHCenter
+                verticalAlignment: Label.AlignVCenter
+                wrapMode: Label.Wrap
+                font.pixelSize: 12
+                font.bold : true
+            }
+            Label {
               id: refreshSec_Text
               anchors.margins: 20
-              anchors.top: text2.bottom
+              anchors.top: text3.bottom
               anchors.left: parent.left
               anchors.right: parent.right
               width: parent.width
@@ -210,7 +223,7 @@ ApplicationWindow {
                 }
               }
           /*    Label {
-                 id:text3
+                 id:text4
                   text: "To disable the alarm set the threshold to 100."
                   font.italic : true
                   anchors.leftMargin: 20
@@ -339,7 +352,7 @@ ApplicationWindow {
                 }
             }
             Label {
-               id:text4
+               id:text5
                 text: "* Before uninstalling the app, be sure to uninstall the indicator here first."
                 font.italic : true
                 font.bold : true


### PR DESCRIPTION
I saw several discussions about the app not working. Mainly because people don't read the README :smirk: .

 So I think it might be good to add a note in the app itself.

Also there is a typo "There availability" should be "Their availability". But I slightly rephrased the sentence, so should be fine now I think.

![grafik](https://github.com/user-attachments/assets/a364335f-6f5d-42ac-a172-83ec33961ca9)
