### PR TITLE
correct OP5T unit

### DIFF
--- a/indicator/devices.json
+++ b/indicator/devices.json
@@ -15,7 +15,7 @@
     },
     "dumpling": {
         "src": "/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-02/800f000.qcom,spmi:qcom,pmi8998@2:qcom,qpnp-smb2/power_supply/battery/current_now",
-        "current_units": "mA",
+        "current_units": "uA",
         "cycle_count":"/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-02/800f000.qcom,spmi:qcom,pmi8998@2:qcom,qpnp-smb2/power_supply/battery/cycle_count",
         "health": "/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-02/800f000.qcom,spmi:qcom,pmi8998@2:qcom,qpnp-smb2/power_supply/battery/health",
         "capacity":"/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-02/800f000.qcom,spmi:qcom,pmi8998@2:qcom,qpnp-smb2/power_supply/battery/capacity",


### PR DESCRIPTION
When doing the initial PR I could not see the result in the indicator. Now I am sure the unit must be `uA`, not `mA`, otherwise the value will be too high. Or can I somehow check that on the device to be 100% sure?