### PR TITLE
add op8t

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Upower is **devices dependent, please** [submit your device data](https://github
 | mido       |    x   |       x      |      x      |    x   |         |        no       |           no           |                      |
 | miatoll    |    x   |       x      |      x      |    x   |         |        no       |           no           |            x         |
 | dumpling   |    x   |       x      |      x      |    x   |         |        x        |           x            |            x         |
+| kebab      |    x   |       x      |      x      |    x   |         |        x        |           x            |            x         |
 | surya/karna|    x   |       x      |      x      |    x   |         |        x        |                        |            x         |
 | FP4        |    x   |       x      |      x      |    x   |         |        x        |                        |            x         |
 | FP5        |    x   |       x      |      x      |    x   |         |        x        |                        |            x         |

--- a/indicator/devices.json
+++ b/indicator/devices.json
@@ -22,6 +22,15 @@
         "status": "/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-02/800f000.qcom,spmi:qcom,pmi8998@2:qcom,qpnp-smb2/power_supply/battery/status",
         "temp": "/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-02/800f000.qcom,spmi:qcom,pmi8998@2:qcom,qpnp-smb2/power_supply/battery/temp"
     },
+    "kebab": {
+        "src": "/sys/devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pm8150b@2:qcom,qpnp-smb5/power_supply/battery/current_now",
+        "current_units": "uA",
+        "cycle_count":"/sys/devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pm8150b@2:qcom,qpnp-smb5/power_supply/battery/cycle_count",
+        "health": "/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-02/800f000.qcom,spmi:qcom,pmi8998@2:qcom,qpnp-smb2/power_supply/battery/health",
+        "capacity":"/sys/devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pm8150b@2:qcom,qpnp-smb5/power_supply/battery/capacity",
+        "status": "/sys/devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pm8150b@2:qcom,qpnp-smb5/power_supply/battery/status",
+        "temp": "/sys/devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pm8150b@2:qcom,qpnp-smb5/power_supply/battery/temp"
+    },
     "cedric": {
         "src": "",
         "current_units": "mA"


### PR DESCRIPTION
Adding readme entry and devices data for OP8T. Note: This is a port WIP, not officially released yet. No idea how long that might take, since some critical issues still need to be resolved.